### PR TITLE
Fix annotation imports

### DIFF
--- a/src/main/java/com/example/moneybutton/alert/RedisAlertBus.java
+++ b/src/main/java/com/example/moneybutton/alert/RedisAlertBus.java
@@ -10,8 +10,8 @@ import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;

--- a/src/main/java/com/example/moneybutton/onnx/OnnxModelService.java
+++ b/src/main/java/com/example/moneybutton/onnx/OnnxModelService.java
@@ -6,7 +6,7 @@ import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;


### PR DESCRIPTION
## Summary
- fix annotation imports for PostConstruct and PreDestroy to use jakarta

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687e411a9f2c8325a33fc33ca51ee0bb