### PR TITLE
Fix ClickHouseConfig signature

### DIFF
--- a/src/main/java/com/example/moneybutton/features/ClickHouseConfig.java
+++ b/src/main/java/com/example/moneybutton/features/ClickHouseConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.sql.Statement;
 
 @Configuration
@@ -22,7 +23,7 @@ public class ClickHouseConfig {
     }
 
     @Bean
-    public DataSource clickHouseDataSource() {
+    public DataSource clickHouseDataSource() throws SQLException {
         return new ClickHouseDataSource(secrets.getClickhouseUrl());
     }
 


### PR DESCRIPTION
## Summary
- allow `clickHouseDataSource` to throw `SQLException`
- this keeps compatibility with `init()` which already declares `throws Exception`

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687ef068680c832591289debbf0366bd