### PR TITLE
Configure Redis connection via REDIS_URL

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: money-button
+  data:
+    redis:
+      url: ${REDIS_URL:redis://localhost:6379}
 
 management:
   endpoints:


### PR DESCRIPTION
## Summary
- read Redis URL from the `REDIS_URL` environment variable

## Testing
- `mvn -q test` *(fails: Non-resolvable POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687eff160f588325b5e762d416506c97