### PR TITLE
Fix ClickHouse config circular dependency

### DIFF
--- a/src/main/java/com/example/moneybutton/features/ClickHouseConfig.java
+++ b/src/main/java/com/example/moneybutton/features/ClickHouseConfig.java
@@ -2,7 +2,6 @@ package com.example.moneybutton.features;
 
 import com.clickhouse.jdbc.ClickHouseDataSource;
 import com.example.moneybutton.SecretsProperties;
-import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -14,11 +13,9 @@ import java.sql.SQLException;
 public class ClickHouseConfig {
 
     private final SecretsProperties secrets;
-    private final JdbcTemplate jdbcTemplate;
 
-    public ClickHouseConfig(SecretsProperties secrets, JdbcTemplate jdbcTemplate) {
+    public ClickHouseConfig(SecretsProperties secrets) {
         this.secrets = secrets;
-        this.jdbcTemplate = jdbcTemplate;
     }
 
     @Bean
@@ -28,12 +25,9 @@ public class ClickHouseConfig {
 
     @Bean
     public JdbcTemplate jdbcTemplate(DataSource dataSource) {
-        return new JdbcTemplate(dataSource);
-    }
-
-    @PostConstruct
-    public void init() {
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
         jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS features_5m (...)");
         jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS feedback (...)");
+        return jdbcTemplate;
     }
 }


### PR DESCRIPTION
## Summary
- prevent `ClickHouseConfig` from demanding `JdbcTemplate` before it's created

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f1abf645c8325a1bb78428a73dc01