### PR TITLE
Improve error handling for Birdeye API

### DIFF
--- a/src/main/java/com/example/moneybutton/birdeye/BirdeyeClient.java
+++ b/src/main/java/com/example/moneybutton/birdeye/BirdeyeClient.java
@@ -2,8 +2,11 @@ package com.example.moneybutton.birdeye;
 
 import com.example.moneybutton.SecretsProperties;
 import com.example.moneybutton.birdeye.dto.TokenMarketDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
@@ -15,6 +18,7 @@ public class BirdeyeClient {
 
     private final WebClient webClient;
     private final SecretsProperties secrets;
+    private static final Logger log = LoggerFactory.getLogger(BirdeyeClient.class);
 
     public BirdeyeClient(WebClient.Builder builder, SecretsProperties secrets) {
         this.webClient = builder.baseUrl("https://public-api.birdeye.so").build();
@@ -22,16 +26,21 @@ public class BirdeyeClient {
     }
 
     public List<TokenMarketDto> getTopTokens(int limit) {
-        return webClient.get()
-                .uri(uriBuilder -> uriBuilder
-                        .path("/defi/tokenlist")
-                        .queryParam("limit", limit)
-                        .build())
-                .header("X-API-KEY", secrets.getBirdeyeKey())
-                .retrieve()
-                .bodyToFlux(TokenMarketDto.class)
-                .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)))
-                .collectList()
-                .block();
+        try {
+            return webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/defi/tokenlist")
+                            .queryParam("limit", limit)
+                            .build())
+                    .header("X-API-KEY", secrets.getBirdeyeKey())
+                    .retrieve()
+                    .bodyToFlux(TokenMarketDto.class)
+                    .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)))
+                    .collectList()
+                    .block();
+        } catch (WebClientResponseException e) {
+            log.warn("Birdeye API error {} - {}", e.getRawStatusCode(), e.getResponseBodyAsString());
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/example/moneybutton/scan/ScanJob.java
+++ b/src/main/java/com/example/moneybutton/scan/ScanJob.java
@@ -44,7 +44,7 @@ public class ScanJob {
 
     @Scheduled(fixedRate = 60_000)
     public void run() {
-        List<TokenMarketDto> tokens = birdeyeClient.getTopTokens(1000);
+        List<TokenMarketDto> tokens = birdeyeClient.getTopTokens(500);
         for (TokenMarketDto dto : tokens) {
             TokenInfo info = enrich(dto);
             if (!filterService.isPass(info)) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,7 @@ secrets:
   minio-secret-key: ${MINIO_SECRET_KEY:minioadmin}
   minio-bucket: ${MINIO_BUCKET:labels}
 
+logging:
+  level:
+    com.example.moneybutton.birdeye: INFO
+


### PR DESCRIPTION
## Summary
- add logging to `BirdeyeClient`
- handle `WebClientResponseException` and log response body
- lower token fetch limit in `ScanJob`
- configure log level for Birdeye client

## Testing
- `mvn -q test` *(fails: Could not transfer artifact software.amazon.awssdk:bom because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687f29680cfc8325bf43254cc4a0ab5a